### PR TITLE
Add documentation on Docker, clarify metric feeding

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,5 @@ Moira was originally developed and is supported by SKB Kontur (https://kontur.ru
 - Alexey Larkov (larkov@skbkontur.ru)
 
 # Contributors
+
+- Toby Jackson (toby.jackson@warmfusion.co.uk)

--- a/source/installation/docker.rst
+++ b/source/installation/docker.rst
@@ -2,7 +2,23 @@ Docker Containers
 =================
 
 .. _Docker: https://github.com/warmfusion/moira-docker
+.. _documentation: https://github.com/warmfusion/moira-docker
 
 .. warning:: This is a third-party installation container provided by community. Use at your own risk.
 
-Toby Jackson kindly provides Docker_ containers for Moira on his GitHub page.
+You can quickly test a local moira installationg using Docker_ containers provided by Toby Jackson.
+
+.. code-block:: bash
+
+  git clone https://github.com/warmfusion/moira-docker.git
+  cd moira-docker
+  docker-compose up
+
+
+.. tip:: If using Docker-Machine you can navigate to the Moira interface on http://$(docker-machine ip dev):8080/
+
+
+This should setup a small cluster of Docker containers ready to accept data and handle notifications, with the interface on ``http://localhost:8080`` and accepts graphite metrics on ``localhost:2003``
+
+See Tobys documentation_ for more information on submitting data to your new containers, and the :userguide:`/user_guide/` for everything else.
+

--- a/source/installation/feeding.rst
+++ b/source/installation/feeding.rst
@@ -3,11 +3,16 @@ Feeding Metrics to Moira
 
 .. _carbon-c-relay: https://github.com/grobian/carbon-c-relay
 
-This is an important and non-obvious part. Default Graphite relay does not support duplicating
-metric stream to several backends, which is how Moira works. Good news is that you probably already
-use a different relay that supports duplication, because the default relay is very slow.
+Moira needs to keep its own local copy of your metric data to improve performance and reduce load
+on your existing graphite cluster. This means data needs to be duplicated from your existing stream
+and sent to your existing cluster and to your moira installation.
 
-Here is an example of carbon-c-relay_ configuration for Moira.
+Unfortunatly, the Carbon-Relay included with Graphite does not support duplication of data to multiple
+backends, and so you need to use a more feature rich carbon relay such as carbon-c-relay_.
+
+The following shows a basic example configuration which defines two clusters and sends all metrics
+to both at once. One cluster is the Moira installation, and the other uses consistent hashing across
+a three node cluster of Carbon servers.
 
 .. code-block:: text
 
@@ -16,8 +21,16 @@ Here is an example of carbon-c-relay_ configuration for Moira.
        moira-host:2003
    ;
 
-   match *
-       send to moira
-   ;
+   cluster graphite
+    carbon_ch
+        127.0.0.1:2006=a
+        127.0.0.1:2007=b
+        127.0.0.1:2008=c
+    ;
 
+   match *
+       send to 
+           moira
+           graphite
+   ;
 .. note:: replace **moira-host** with your host name

--- a/source/installation/index.rst
+++ b/source/installation/index.rst
@@ -5,7 +5,7 @@ Installation
    :maxdepth: 1
 
    manual
-   configuration
    docker
+   configuration
    feeding
    security

--- a/source/installation/manual.rst
+++ b/source/installation/manual.rst
@@ -7,6 +7,9 @@ Manual Installation
 .. _nginx: http://nginx.org/en/download.html
 .. _config.json: https://github.com/moira-alert/web/blob/master/config.json.example
 
+
+.. tip: For a quick-start getting Moira working, why not try out a :docker:`/installation/docker` version
+
 There are following components you need to install before running Moira microservices:
 
 1. golang_ version 1.4 or higher

--- a/source/spelling_wordlist.txt
+++ b/source/spelling_wordlist.txt
@@ -14,7 +14,7 @@ app
 teamcity
 Dataflow
 incomming
-delpoy
+deploy
 api
 screenshots
 ui


### PR DESCRIPTION
Expanded upon the Docker documentation by adding some quick information on how to get started,
and added a bit more clarity on the carbon-c-relay and feeding data into moira.
