### PR TITLE
prepare doc repo for openapi files

### DIFF
--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12-alpine as builder
+WORKDIR /moira-oas
+RUN npm install -g swagger-cli
+
+COPY . /moira-oas/
+RUN swagger-cli bundle main.yml -o build/openapi.yml -t yaml
+
+FROM swaggerapi/swagger-ui:latest
+COPY --from=builder /moira-oas/build/openapi.yml /openapi.yml
+ENV SWAGGER_JSON=/openapi.yml
+
+EXPOSE 8080
+

--- a/openapi/Makefile
+++ b/openapi/Makefile
@@ -1,0 +1,23 @@
+BUILD_DIR = build
+SPEC_FILE = $(BUILD_DIR)/openapi.yml
+CLIENTS_DIR = $(BUILD_DIR)/clients
+NETWORK_LOG = $(BUILD_DIR)/cassette.yml
+API_URL = "http://localhost:8080/api"
+
+spec:
+	swagger-cli bundle main.yml -o $(SPEC_FILE) -t yaml
+	
+validate-spec:
+	openapi-generator validate -i $(SPEC_FILE)
+
+test-spec:
+	schemathesis run --base-url=$(API_URL) $(SPEC_FILE) -c all --hypothesis-max-examples 1 --store-network-log $(NETWORK_LOG)
+
+generate-py:
+	openapi-generator generate -g python -i $(SPEC_FILE) -o $(CLIENTS_DIR)/python
+generate-go:
+	openapi-generator generate -g go -i $(SPEC_FILE) -o $(CLIENTS_DIR)/go
+generate-ts:
+	openapi-generator generate -g typescript-node -i $(SPEC_FILE) -o $(CLIENTS_DIR)/ts-node
+generate-cs:
+	openapi-generator generate -g csharp -i $(SPEC_FILE) -o $(CLIENTS_DIR)/csharp

--- a/openapi/Makefile
+++ b/openapi/Makefile
@@ -6,18 +6,19 @@ API_URL = "http://localhost:8080/api"
 
 spec:
 	swagger-cli bundle main.yml -o $(SPEC_FILE) -t yaml
-	
+
 validate-spec:
 	openapi-generator validate -i $(SPEC_FILE)
-
-test-spec:
-	schemathesis run --base-url=$(API_URL) $(SPEC_FILE) -c all --hypothesis-max-examples 1 --store-network-log $(NETWORK_LOG)
-
+	
 generate-py:
 	openapi-generator generate -g python -i $(SPEC_FILE) -o $(CLIENTS_DIR)/python
+
 generate-go:
 	openapi-generator generate -g go -i $(SPEC_FILE) -o $(CLIENTS_DIR)/go
+
 generate-ts:
 	openapi-generator generate -g typescript-node -i $(SPEC_FILE) -o $(CLIENTS_DIR)/ts-node
+
 generate-cs:
 	openapi-generator generate -g csharp -i $(SPEC_FILE) -o $(CLIENTS_DIR)/csharp
+

--- a/openapi/Makefile
+++ b/openapi/Makefile
@@ -1,24 +1,9 @@
 BUILD_DIR = build
 SPEC_FILE = $(BUILD_DIR)/openapi.yml
-CLIENTS_DIR = $(BUILD_DIR)/clients
-NETWORK_LOG = $(BUILD_DIR)/cassette.yml
-API_URL = "http://localhost:8080/api"
 
 spec:
 	swagger-cli bundle main.yml -o $(SPEC_FILE) -t yaml
 
 validate-spec:
 	openapi-generator validate -i $(SPEC_FILE)
-	
-generate-py:
-	openapi-generator generate -g python -i $(SPEC_FILE) -o $(CLIENTS_DIR)/python
-
-generate-go:
-	openapi-generator generate -g go -i $(SPEC_FILE) -o $(CLIENTS_DIR)/go
-
-generate-ts:
-	openapi-generator generate -g typescript-node -i $(SPEC_FILE) -o $(CLIENTS_DIR)/ts-node
-
-generate-cs:
-	openapi-generator generate -g csharp -i $(SPEC_FILE) -o $(CLIENTS_DIR)/csharp
 

--- a/openapi/docker-compose.yml
+++ b/openapi/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+  redoc:
+    image: redocly/redoc
+    container_name: moira_docs_redoc
+    ports:
+    - "9901:80"
+    volumes:
+    - ./build/openapi.yml:/usr/share/nginx/html/openapi/openapi.yml
+    environment:
+      SPEC_URL: openapi/openapi.yml
+      PAGE_TITLE: "Moira API Description"
+
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    container_name: moira_docs_swaggerui
+    ports:
+      - "9900:8080"
+    volumes:
+    - ./build/openapi.yml:/openapi.yml
+    environment:
+      SWAGGER_JSON: /openapi.yml
+


### PR DESCRIPTION
This PR creates an `openapi` folder which will be the folder for all `yml` files relating to the OpenAPI documentation. It also includes basic files (i.e the Makefile for project actions, docker-compose and the Dockerfile).