### PR TITLE
set up actions workflow and config documentation

### DIFF
--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -1,0 +1,26 @@
+name: Delete spec version from SwaggerHub
+
+on:
+  [delete]
+
+jobs:
+  removespec:
+    name: Remove the corresponding spec from SwaggerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set output for versioning
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: remove spec from swaggerhub
+        env:
+          AUTH_TOKEN: ${{secrets.SGH_TOKEN}}
+          RELEASE_VERSION: ${{ github.event.ref }}
+        shell: bash
+        run: |
+          version=${RELEASE_VERSION}
+          version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
+          echo "removing API spec: ${version} from swaggerhub"
+          curl -X DELETE "https://api.swaggerhub.com/apis/idoko/moira-alert/${version}" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"

--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -16,12 +16,10 @@ jobs:
 
       - name: remove spec from swaggerhub
         env:
-          auth_token: ${{secrets.SWAGGERHUB_TOKEN}}
-          release_version: ${{ github.event.ref }}
-          swaggerhub_url: "https://api.swaggerhub.com/apis/idoko/moira-alert"
+          AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
+          BRANCH_NAME: ${{ github.event.ref }}
+          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/moira/moira-alert"
         shell: bash
         run: |
-          version=${release_version}
-          version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
-          echo "removing API spec: ${version} from swaggerhub"
-          curl -X DELETE "${swaggerhub_url}/${version}" -H "content-type: application/yaml" -H "Authorization: ${auth_token}"
+          VERSION=`echo ${BRANCH_NAME}|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
+          curl -X DELETE "${SWAGGERHUB_URL}/${VERSION}" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"

--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -12,16 +12,16 @@ jobs:
       - uses: actions/checkout@v2
       - name: set output for versioning
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo ::set-output name=tag::"${GITHUB_REF#refs/*/}"
 
       - name: remove spec from swaggerhub
         env:
-          AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
-          RELEASE_VERSION: ${{ github.event.ref }}
-          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/idoko/moira-alert"
+          auth_token: ${{secrets.SWAGGERHUB_TOKEN}}
+          release_version: ${{ github.event.ref }}
+          swaggerhub_url: "https://api.swaggerhub.com/apis/idoko/moira-alert"
         shell: bash
         run: |
-          version=${RELEASE_VERSION}
+          version=${release_version}
           version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
           echo "removing API spec: ${version} from swaggerhub"
-          curl -X DELETE "${SWAGGERHUB_URL}/${version}" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"
+          curl -X DELETE "${swaggerhub_url}/${version}" -H "content-type: application/yaml" -H "Authorization: ${auth_token}"

--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -16,11 +16,12 @@ jobs:
 
       - name: remove spec from swaggerhub
         env:
-          AUTH_TOKEN: ${{secrets.SGH_TOKEN}}
+          AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
           RELEASE_VERSION: ${{ github.event.ref }}
+          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/idoko/moira-alert"
         shell: bash
         run: |
           version=${RELEASE_VERSION}
           version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
           echo "removing API spec: ${version} from swaggerhub"
-          curl -X DELETE "https://api.swaggerhub.com/apis/idoko/moira-alert/${version}" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"
+          curl -X DELETE "${SWAGGERHUB_URL}/${version}" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: set output for versioning
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo ::set-output name=tag::"${GITHUB_REF#refs/*/}"
 
       - run: mkdir build/
       - name: Download spec file artifact
@@ -53,13 +53,13 @@ jobs:
 
       - name: Upload spec file to swaggerhub
         env:
-          AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
-          RELEASE_VERSION: ${{steps.vars.outputs.tag}}
-          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/idoko/moira-alert"
+          auth_token: ${{secrets.SWAGGERHUB_TOKEN}}
+          release_version: ${{steps.vars.outputs.tag}}
+          swaggerhub_url: "https://api.swaggerhub.com/apis/idoko/moira-alert"
         shell: bash
         run: |
           version=${RELEASE_VERSION}
           version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
           echo "Uploading OpenAPI spec v ${RELEASE_VERSION}"
           def=`cat ./build/openapi.yml`
-          curl -d "$def" "${SWAGGERHUB_URL}/?isPrivate=false&version=${version}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"
+          curl -d "$def" "${swaggerhub_url}/?isPrivate=false&version=${version}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${auth_token}"

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -23,7 +23,6 @@ jobs:
           node-version: '14'
       - run: npm install -g swagger-cli
       - run: make spec
-      - run: pwd
 
       - name: Save build artifact
         uses: actions/upload-artifact@v1
@@ -54,13 +53,13 @@ jobs:
 
       - name: Upload spec file to swaggerhub
         env:
-          AUTH_TOKEN: ${{secrets.SGH_TOKEN}}
+          AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
           RELEASE_VERSION: ${{steps.vars.outputs.tag}}
+          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/idoko/moira-alert"
         shell: bash
         run: |
           version=${RELEASE_VERSION}
           version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
           echo "Uploading OpenAPI spec v ${RELEASE_VERSION}"
-          pwd
           def=`cat ./build/openapi.yml`
-          curl -d "$def" "https://api.swaggerhub.com/apis/idoko/moira-alert/?isPrivate=false&version=${version}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"
+          curl -d "$def" "${SWAGGERHUB_URL}/?isPrivate=false&version=${version}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -1,0 +1,66 @@
+name: Publish spec version to SwaggerHub
+
+on:
+  push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.[0-9]+
+      - feature/*
+
+jobs:
+  mergespec:
+    name: Bundle spec files and validate it.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: openapi
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: npm install -g swagger-cli
+      - run: make spec
+      - run: pwd
+
+      - name: Save build artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: specfile
+          path: openapi/build/openapi.yml
+    
+  publishspec:
+    name: Upload generated OpenAPI description
+    runs-on: ubuntu-latest
+    needs: mergespec
+    defaults:
+      run:
+        working-directory: openapi
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set output for versioning
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - run: mkdir build/
+      - name: Download spec file artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: specfile
+          path: openapi/build
+
+      - name: Upload spec file to swaggerhub
+        env:
+          AUTH_TOKEN: ${{secrets.SGH_TOKEN}}
+          RELEASE_VERSION: ${{steps.vars.outputs.tag}}
+        shell: bash
+        run: |
+          version=${RELEASE_VERSION}
+          version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
+          echo "Uploading OpenAPI spec v ${RELEASE_VERSION}"
+          pwd
+          def=`cat ./build/openapi.yml`
+          curl -d "$def" "https://api.swaggerhub.com/apis/idoko/moira-alert/?isPrivate=false&version=${version}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -53,13 +53,11 @@ jobs:
 
       - name: Upload spec file to swaggerhub
         env:
-          auth_token: ${{secrets.SWAGGERHUB_TOKEN}}
-          release_version: ${{steps.vars.outputs.tag}}
-          swaggerhub_url: "https://api.swaggerhub.com/apis/idoko/moira-alert"
+          AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
+          BRANCH_NAME: ${{steps.vars.outputs.tag}}
+          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/moira/moira-alert"
         shell: bash
         run: |
-          version=${RELEASE_VERSION}
-          version=`echo $version|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
-          echo "Uploading OpenAPI spec v ${RELEASE_VERSION}"
-          def=`cat ./build/openapi.yml`
-          curl -d "$def" "${swaggerhub_url}/?isPrivate=false&version=${version}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${auth_token}"
+          VERSION=`echo ${BRANCH_NAME}|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`
+          DEFINITION=`cat ./build/openapi.yml`
+          curl -d "$DEFINITION" "${SWAGGERHUB_URL}/?isPrivate=false&version=${VERSION}&oas=3.0.0&force=true" -H "content-type: application/yaml" -H "Authorization: ${AUTH_TOKEN}"

--- a/openapi/config/methods.yml
+++ b/openapi/config/methods.yml
@@ -1,0 +1,7 @@
+get:
+  summary: "Get available configuration"
+  operationId: GetConfig
+  tags:
+    - config
+  responses:
+    $ref: ./responses.yml#/get

--- a/openapi/config/responses.yml
+++ b/openapi/config/responses.yml
@@ -1,0 +1,26 @@
+get:
+  200:
+    description: "Configuration fetched successfully."
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            remoteAllowed:
+              type: boolean
+              description: Flag for determining if Moira is accessible remotely.
+              example: false
+            contacts:
+              type: array
+              description: List of enabled contact types
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: The type of contact
+                    example: telegram
+                  label:
+                    type: string
+                    description: Human readable label of the contact
+                    example: Telegram

--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  description: "This is an API description for Moira Alert project. Please check https://github.com/moira-alert"
+  version: "2.5.1.48"
+  title: "Moira Alert"
+  license:
+    name: "MIT"
+tags:
+  - name: "config"
+    description: "View Moira's runtime configuration"
+ 
+
+servers:
+  - url: http://localhost:8080/api
+    description: Localhost server
+paths:
+  /config:
+    $ref: ./config/methods.yml
+  


### PR DESCRIPTION
This adds the Github Actions workflow for publishing OpenAPI definitions to SwaggerHub and deleting them. It also includes a documentation for the `config` route so that CI has something to work with.

To make it work, we will need a [SwaggerHub account](https://app.swaggerhub.com/signup), and a Github secret named `SGH_TOKEN` which contains the [SwaggerHub API token](https://app.swaggerhub.com/settings/apiKey).