### PR TITLE
use uppercase in swaggerhub url

### DIFF
--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
           BRANCH_NAME: ${{ github.event.ref }}
-          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/moira/moira-alert"
+          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/Moira/moira-alert"
         shell: bash
         run: |
           VERSION=`echo ${BRANCH_NAME}|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
           BRANCH_NAME: ${{steps.vars.outputs.tag}}
-          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/moira/moira-alert"
+          SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/Moira/moira-alert"
         shell: bash
         run: |
           VERSION=`echo ${BRANCH_NAME}|sed 's#[^a-zA-Z0-9_\.\-]#_#g'`


### PR DESCRIPTION
Organization names are case-sensitive on SwaggerHub, which causes the API definition to not show up after being published. This commit changes `moira` to `Moira` to help fix that.