### PR TITLE
Add documentation for /contact path

### DIFF
--- a/openapi/config/methods.yml
+++ b/openapi/config/methods.yml
@@ -1,5 +1,5 @@
 get:
-  summary: "Get available configuration"
+  summary: "Get the runtime configuration."
   operationId: GetConfig
   tags:
     - config

--- a/openapi/contact/methods.yml
+++ b/openapi/contact/methods.yml
@@ -1,0 +1,58 @@
+contacts:
+  get:
+    summary: "Gets all Moira contacts."
+    operationId: GetContacts
+    tags:
+      - contact
+    responses:
+      $ref: ./responses.yml#/getContacts
+  put:
+    summary: "Creates a new contact notification for the current user."
+    operationId: CreateNewContact
+    tags:
+      - contact
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ./requests.yml#/newContact
+    responses:
+      $ref: ./responses.yml#/newContact
+contact:
+  put:
+    summary: "Updates an existing notification contact to the values passed in the request body."
+    operationId: UpdateContact
+    tags:
+      - contact
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/contactId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ./requests.yml#/updateContact
+    responses:
+      $ref: ./responses.yml#/updateContact
+  delete:
+    summary: "Deletes notification contact for the current user and remove the contact ID from all subscriptions."
+    operationId: DeleteContact
+    tags:
+      - contact
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/contactId
+    responses:
+      $ref: ./responses.yml#/deleteContact
+
+
+testContact:
+  post:
+    summary: "Push a test notification to verify that the contact is properly set up."
+    operationId: TestContactNotification
+    tags:
+      - contact
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/contactId
+    responses:
+      $ref: ./responses.yml#/testContactNotification

--- a/openapi/contact/requests.yml
+++ b/openapi/contact/requests.yml
@@ -1,0 +1,4 @@
+newContact:
+  $ref: "../shared/schemas/Contact.yml#/ContactRequest"
+updateContact:
+  $ref: "../shared/schemas/Contact.yml#/ContactRequest"

--- a/openapi/contact/responses.yml
+++ b/openapi/contact/responses.yml
@@ -1,0 +1,52 @@
+getContacts:
+  200:
+    description: "Contacts fetched successfully"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            list:
+              type: array
+              description: "List of all the retrieved Moira contacts."
+              items:
+                $ref: "../shared/schemas/Contact.yml#/Contact"
+
+newContact:
+  200:
+    description: "Contact created successfully."
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Contact.yml#/Contact"
+
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"
+
+updateContact:
+  200:
+    description: "Contact has been updated"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Contact.yml#/Contact"
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"
+  404:
+    $ref: "../shared/responses/_index.yml#/NotFound"
+
+deleteContact:
+  200:
+    description: "Contact has been deleted"
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"
+  404:
+    $ref: "../shared/responses/_index.yml#/NotFound"
+
+testContactNotification:
+  200:
+    description: "Test successful."
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"
+  404:
+    $ref: "../shared/responses/_index.yml#/NotFound"

--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -1,13 +1,13 @@
 openapi: 3.0.0
 info:
-  description: "This is an API description for Moira Alert project. Please check https://github.com/moira-alert"
+  description: "This is an API description for [Moira Alert API](https://moira.readthedocs.io/en/latest/overview.html). Check us out on [Github](https://github.com/moira-alert) or look up our [guide on getting started with Moira](https://moira.readthedocs.io)."
   version: "2.5.1.48"
   title: "Moira Alert"
   license:
     name: "MIT"
 tags:
   - name: "config"
-    description: "View Moira's runtime configuration"
+    description: "View Moira's runtime configuration. For more details, see <https://moira.readthedocs.io/en/latest/installation/configuration.html/>"
  
 
 servers:

--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -8,7 +8,8 @@ info:
 tags:
   - name: "config"
     description: "View Moira's runtime configuration. For more details, see <https://moira.readthedocs.io/en/latest/installation/configuration.html/>"
- 
+  - name: "contact"
+    description: "APIs for working with Moira contacts. For more details, see <https://moira.readthedocs.io/en/latest/installation/webhooks_scripts.html#contact/>"
 
 servers:
   - url: http://localhost:8080/api
@@ -16,4 +17,19 @@ servers:
 paths:
   /config:
     $ref: ./config/methods.yml
+  /contact:
+    $ref: ./contact/methods.yml#/contacts
+  /contact/{contactId}:
+    $ref: ./contact/methods.yml#/contact
+  /contact/{contactId}/test:
+    $ref: ./contact/methods.yml#/testContact
+
+components:
+  schemas:
+    $ref: "./shared/schemas/_index.yml"
+  parameters:
+    $ref: "./shared/parameters/_index.yml"
+  responses:
+    $ref: "./shared/responses/_index.yml"
+
   

--- a/openapi/shared/parameters/_index.yml
+++ b/openapi/shared/parameters/_index.yml
@@ -1,0 +1,9 @@
+contactId:
+  in: path
+  name: contactId
+  required: true
+  schema:
+    type: string
+    format: uuid
+  description: The ID of the target contact
+  example: "bcba82f5-48cf-44c0-b7d6-e1d32c64a88c"

--- a/openapi/shared/responses/_index.yml
+++ b/openapi/shared/responses/_index.yml
@@ -1,0 +1,59 @@
+BadRequest:
+  description: "Bad request from client"
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          status:
+            description: "Generic error status text"
+            type: string
+          error:
+            type: string
+            description: "Message telling why the error occurred"
+      examples:
+        missingID:
+          description: "no resource with the provided ID was found"
+          value:
+            status: "invalid request"
+            error: "resource with the ID does not exist"
+
+NotFound:
+  description: "Trigger not found"
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          status:
+            description: "Generic error status text"
+            type: string
+          error:
+            description: "Error message that describes the missing resource."
+            type: string
+      examples:
+        missingTrigger:
+          description: "Trigger with given ID not found"
+          value:
+            status: "resource not found"
+            example: "trigger with ID '66741a8c-c2ba-4357-a2c9-ee78e0e7' does not exist"
+
+ServerError:
+  description: "Server error"
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          status:
+            description: "Generic error status text"
+            type: string
+          error:
+            description: "Message describing the error that occurred."
+            type: string
+      examples:
+        renderingFailed:
+          description: "Failed to render trigger chart"
+          value:
+            status: "Internal Server Error"
+            error: "no points found to render trigger: 5A8AF369-86D2-44DD-B514-D47995ED6AF7"

--- a/openapi/shared/schemas/Contact.yml
+++ b/openapi/shared/schemas/Contact.yml
@@ -1,0 +1,29 @@
+ContactRequest:
+  type: object
+  description: "Format of the request body for POST/PUT requests to `/contacts` and related sub-paths."
+  properties:
+    type:
+      type: string
+      example: "mail"
+    value:
+      type: string
+      example: "devops@example.com"
+
+Contact:
+  type: object
+  description: "Format for responses that gives a contact object."
+  properties:
+    id:
+      type: string
+      description: "ID of the contact"
+      example: "1dd38765-c5be-418d-81fa-7a5f879c2315"
+    user:
+      type: string
+      description: "Username of the user who created the contact"
+      example: ""
+    type:
+      type: string
+      example: "mail"
+    value:
+      type: string
+      example: "devops@example.com"

--- a/openapi/shared/schemas/_index.yml
+++ b/openapi/shared/schemas/_index.yml
@@ -1,0 +1,4 @@
+Contact:
+  $ref: "./Contact.yml#/Contact"
+ContactRequest:
+  $ref: "./Contact.yml#/ContactRequest"


### PR DESCRIPTION
This adds the OpenAPI documentation for paths relating to `/contacts` (i.e `contact`, `contact/{contactId}`, and `/contact/{contactId}/test`.

Additionally, it sets up the folder structure for parts of OpenAPI description that is shared such as error responses, and schemas (which are usually generated from Moira `dto` files) as they are needed for the `contacts` description to work.