### PR TITLE
fix actions not running on PRs to master

### DIFF
--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -1,7 +1,16 @@
 name: Delete spec version from SwaggerHub
+defaults:
+  run:
+    working-directory: openapi
 
 on:
-  [delete]
+  pull_request:
+    types: [closed]
+  delete:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.[0-9]+
+      - feature/*
 
 jobs:
   removespec:
@@ -10,9 +19,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: set output for versioning
-        id: vars
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/*/}"
+      - name: Extract branch name on branch delete
+        if: github.event_name != 'pull_request'
+        id: extract_branch_name
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${{ github.event.ref }})"
+
+      - name: Extract branch name on PR closed or merged
+        if: github.event_name == 'pull_request'
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
 
       - name: remove spec from swaggerhub
         env:

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -1,6 +1,9 @@
 name: Publish spec version to SwaggerHub
 
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
@@ -40,9 +43,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: set output for versioning
-        id: vars
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/*/}"
+
+      - name: Extract branch name on push
+        if: github.event_name != 'pull_request'
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
+
+      - name: Extract branch name on PR
+        if: github.event_name == 'pull_request'
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
+
 
       - run: mkdir build/
       - name: Download spec file artifact
@@ -54,7 +63,6 @@ jobs:
       - name: Upload spec file to swaggerhub
         env:
           AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
-          BRANCH_NAME: ${{steps.vars.outputs.tag}}
           SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/moira/moira-alert"
         shell: bash
         run: |


### PR DESCRIPTION
This adds the `pull_request` event to our GitHub Actions workflow so CI is triggered on PR to master branch. It also improves the swaggerhub-delete workflow so that versions are deleted when the related PR/branch is closed (even if they were not merged).

I've tested both workflows on [idoqo/moria-oas](https://github.com/idoqo/moira-oas) but will keep an eye on how they work when I make new PRs, especially as they're not exactly the same thing.