### PR TITLE
Improve pipeline actions for PRs

### DIFF
--- a/.github/workflows/swaggerhub-delete.yml
+++ b/.github/workflows/swaggerhub-delete.yml
@@ -1,7 +1,16 @@
 name: Delete spec version from SwaggerHub
+defaults:
+  run:
+    working-directory: openapi
 
 on:
-  [delete]
+  pull_request:
+    types: [closed]
+  delete:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.[0-9]+
+      - feature/*
 
 jobs:
   removespec:
@@ -10,9 +19,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: set output for versioning
-        id: vars
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/*/}"
+      - name: Extract branch name on branch delete
+        if: github.event_name != 'pull_request'
+        id: extract_branch_name
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${{ github.event.ref }})"
+
+      - name: Extract branch name on PR closed or merged
+        if: github.event_name == 'pull_request'
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
 
       - name: remove spec from swaggerhub
         env:

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -1,9 +1,6 @@
 name: Publish spec version to SwaggerHub
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
@@ -24,8 +21,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14'
-      - run: npm install -g swagger-cli
+      - run: npm install -g swagger-cli @openapitools/openapi-generator-cli
       - run: make spec
+      - run: make validate-spec
 
       - name: Save build artifact
         uses: actions/upload-artifact@v1
@@ -47,11 +45,6 @@ jobs:
       - name: Extract branch name on push
         if: github.event_name != 'pull_request'
         run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
-
-      - name: Extract branch name on PR
-        if: github.event_name == 'pull_request'
-        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
-
 
       - run: mkdir build/
       - name: Download spec file artifact

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -1,6 +1,9 @@
 name: Publish spec version to SwaggerHub
 
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
@@ -40,9 +43,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: set output for versioning
-        id: vars
-        run: echo ::set-output name=tag::"${GITHUB_REF#refs/*/}"
+
+      - name: Extract branch name on push
+        if: github.event_name != 'pull_request'
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
+
+      - name: Extract branch name on PR
+        if: github.event_name == 'pull_request'
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
+
 
       - run: mkdir build/
       - name: Download spec file artifact
@@ -54,7 +63,6 @@ jobs:
       - name: Upload spec file to swaggerhub
         env:
           AUTH_TOKEN: ${{secrets.SWAGGERHUB_TOKEN}}
-          BRANCH_NAME: ${{steps.vars.outputs.tag}}
           SWAGGERHUB_URL: "https://api.swaggerhub.com/apis/moira/moira-alert"
         shell: bash
         run: |

--- a/.github/workflows/validate-on-pr.yml
+++ b/.github/workflows/validate-on-pr.yml
@@ -1,0 +1,30 @@
+name: Validate OpenAPI spec on new PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  mergespec:
+    name: Bundle spec files and validate it.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: openapi
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: npm install -g swagger-cli @openapitools/openapi-generator-cli
+      - run: make spec
+      - run: make validate-spec
+
+      - name: Save build artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: specfile
+          path: openapi/build/openapi.yml


### PR DESCRIPTION
This PR overrides #58. It modifies Actions to only build and validate the OpenAPI spec for PRs (without publishing them to SwaggerHub) - since external PR branches can't access the `SWAGGERHUB_TOKEN` anyway.

It also add [openapi-generator-cli](https://github.com/OpenAPITools/openapi-generator-cli) as part of the CI process to check that API definition is at least valid.