### PR TITLE
add documentation for /health path

### DIFF
--- a/openapi/health/methods.yml
+++ b/openapi/health/methods.yml
@@ -1,0 +1,33 @@
+notifier:
+  get:
+    summary: "Get notifier state"
+    operationId: GetNotifierState
+    tags:
+      - health
+    responses:
+      $ref: ./responses.yml#/getNotifierState
+
+  put:
+    summary: "Update notifier state"
+    operationId: UpdateNotifierState
+    tags:
+      - health
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ./requests.yml#/updateNotifierState
+          examples:
+            ok:
+              summary: "change the notifier state to OK"
+              value:
+                state: "OK"
+                message: ""
+            error:
+              summary: "put the notifier service in an ERROR state"
+              value:
+                state: "ERROR"
+                message: "Turned off for maintenance"
+    responses:
+      $ref: ./responses.yml#/updateNotifierState

--- a/openapi/health/requests.yml
+++ b/openapi/health/requests.yml
@@ -1,0 +1,2 @@
+updateNotifierState:
+  $ref: "../shared/schemas/NotifierState.yml#/NotifierState"

--- a/openapi/health/responses.yml
+++ b/openapi/health/responses.yml
@@ -1,0 +1,39 @@
+getNotifierState:
+  200:
+    description: "Notifier state retrieved"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/NotifierState.yml#/NotifierState"
+        examples:
+          error:
+            description: "Put the service in an ERROR state"
+            value:
+              state: "ERROR"
+              message: "Moira has been turned off for maintenance"
+          ok:
+            description: "Put the service in an OK state"
+            value:
+              state: "OK"
+              description: ""
+
+updateNotifierState:
+  200:
+    description: "Update state of the Moira service"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/NotifierState.yml#/NotifierState"
+        examples:
+          error:
+            description: "Put the service in an ERROR state"
+            value:
+              state: "ERROR"
+              message: "Moira has been turned off for maintenance"
+          ok:
+            description: "Put the service in an OK state"
+            value:
+              state: "OK"
+              description: ""
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"

--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -11,7 +11,9 @@ tags:
   - name: "contact"
     description: "APIs for working with Moira contacts. For more details, see <https://moira.readthedocs.io/en/latest/installation/webhooks_scripts.html#contact/>"
   - name: "event"
-    description: "APIs for interacting with notification events. see <https://moira.readthedocs.io/en/latest/user_guide/trigger_page.html#event-history/> for details"
+    description: "APIs for interacting with notification events. See <https://moira.readthedocs.io/en/latest/user_guide/trigger_page.html#event-history/> for details"
+  - name: "health"
+    description: "interact with Moira states/health status. See <https://moira.readthedocs.io/en/latest/user_guide/selfstate.html?highlight=health#self-state-monitor/> for details."
 
 servers:
   - url: http://localhost:8080/api
@@ -29,6 +31,8 @@ paths:
     $ref: ./event/methods.yml#/events
   /event/{triggerID}:
     $ref: ./event/methods.yml#/eventForTrigger
+  /health/notifier:
+    $ref: ./health/methods.yml#/notifier
 
 components:
   schemas:

--- a/openapi/shared/schemas/NotifierState.yml
+++ b/openapi/shared/schemas/NotifierState.yml
@@ -1,0 +1,10 @@
+NotifierState:
+  type: object
+  properties:
+    state:
+      type: string
+      description: "New state of the notifier service. Should be either OK or ERROR"
+      example: "OK"
+    message:
+      type: string
+      description: "Optional description for the state change"

--- a/openapi/shared/schemas/_index.yml
+++ b/openapi/shared/schemas/_index.yml
@@ -4,3 +4,5 @@ ContactRequest:
   $ref: "./Contact.yml#/ContactRequest"
 Event:
   $ref: "./Event.yml#/Event"
+NotifierState:
+  $ref: "./NotifierState.yml#/NotifierState"


### PR DESCRIPTION
This adds documentation for the Moira health check endpoint (`/health/notifier`) endpoint to the OpenAPI spec. 