### PR TITLE
add documentation for /pattern

### DIFF
--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -16,6 +16,8 @@ tags:
     description: "interact with Moira states/health status. See <https://moira.readthedocs.io/en/latest/user_guide/selfstate.html#self-state-monitor/> for details."
   - name: "notifications"
     description: "manage notifications that are currently in queue. See <https://moira.readthedocs.io/en/latest/user_guide/hidden_pages.html#notifications/>"
+  - name: "pattern"
+    description: "APIs for interacting with graphite patterns in Moira. See <https://moira.readthedocs.io/en/latest/development/architecture.html#pattern/>"
 
 servers:
   - url: http://localhost:8080/api
@@ -39,6 +41,10 @@ paths:
     $ref: ./notification/methods.yml#/notifications
   /notification/all:
     $ref: ./notification/methods.yml#/all
+  /pattern:
+    $ref: ./pattern/methods.yml#/patterns
+  /pattern/{pattern}:
+    $ref: ./pattern/methods.yml#/pattern
 
 components:
   schemas:

--- a/openapi/pattern/methods.yml
+++ b/openapi/pattern/methods.yml
@@ -1,0 +1,19 @@
+patterns:
+  get:
+    summary: "Get all patterns"
+    operationId: GetAllPatterns
+    tags:
+      - pattern
+    responses:
+      $ref: ./responses.yml#/getPatterns
+
+pattern:
+  delete:
+    summary: "Deletes a Moira pattern"
+    operationId: DeletePattern
+    tags:
+      - pattern
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/pattern
+    responses:
+      $ref: ./responses.yml#/deletePattern

--- a/openapi/pattern/responses.yml
+++ b/openapi/pattern/responses.yml
@@ -1,0 +1,17 @@
+getPatterns:
+  200:
+    description: "Patterns fetched successfully"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            list:
+              type: array
+              description: "List of fetched patterns"
+              items:
+                $ref: "../shared/schemas/Pattern.yml#/Pattern"
+
+deletePattern:
+  200:
+    description: "Pattern delete successfully"

--- a/openapi/shared/parameters/_index.yml
+++ b/openapi/shared/parameters/_index.yml
@@ -36,6 +36,15 @@ page:
   description: "Defines the number of the displayed page. E.g, page=2 would display the 2nd page."
   example: 1
 
+pattern:
+  in: path
+  name: pattern
+  required: true
+  schema:
+    type: string
+  example: "DevOps.my_server.hdd.freespace_mbytes"
+  description: "Trigger pattern to operate on."
+
 size:
   in: query
   name: size

--- a/openapi/shared/schemas/Pattern.yml
+++ b/openapi/shared/schemas/Pattern.yml
@@ -1,0 +1,18 @@
+Pattern:
+  type: object
+  properties:
+    metrics:
+      type: array
+      items:
+        type: string
+      example:
+        - "DevOps.my_server.hdd.freespace_mbytes"
+        - "DevOps.my_server.hdd.usedspace_mbytes"
+        - "DevOps.my_server.db.*"
+    pattern:
+      type: string
+      example: "Devops.my_server.*"
+    triggers:
+      type: array
+      items:
+        "$ref": "./Trigger.yml#/Trigger"

--- a/openapi/shared/schemas/_index.yml
+++ b/openapi/shared/schemas/_index.yml
@@ -8,5 +8,7 @@ NotificationsList:
   $ref: "./NotificationsList.yml#/NotificationsList"
 NotifierState:
   $ref: "./NotifierState.yml#/NotifierState"
+Pattern:
+  $ref: "./Pattern.yml#/Pattern"
 Trigger:
   $ref: "./Trigger.yml#/Trigger"


### PR DESCRIPTION
This adds the OpenAPI documentation and components necessary for the `pattern` path and its subpaths (i.e `/pattern` and `/pattern/{pattern}`.