### PR TITLE
add documentation for /subscription path

### DIFF
--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -18,6 +18,8 @@ tags:
     description: "manage notifications that are currently in queue. See <https://moira.readthedocs.io/en/latest/user_guide/hidden_pages.html#notifications/>"
   - name: "pattern"
     description: "APIs for interacting with graphite patterns in Moira. See <https://moira.readthedocs.io/en/latest/development/architecture.html#pattern/>"
+  - name: "subscription"
+    description: "APIs for managing a user's subscription(s). See <https://moira.readthedocs.io/en/latest/development/architecture.html#subscription/> to learn about Moira subscriptions."
 
 servers:
   - url: http://localhost:8080/api
@@ -45,6 +47,13 @@ paths:
     $ref: ./pattern/methods.yml#/patterns
   /pattern/{pattern}:
     $ref: ./pattern/methods.yml#/pattern
+  /subscription:
+    $ref: ./subscription/methods.yml#/subscriptions
+  /subscription/{subscriptionId}:
+    $ref: ./subscription/methods.yml#/subscription
+  /subscription/{subscriptionId}/test:
+    $ref: ./subscription/methods.yml#/test
+
 
 components:
   schemas:

--- a/openapi/shared/parameters/_index.yml
+++ b/openapi/shared/parameters/_index.yml
@@ -63,6 +63,15 @@ start:
     default: 0
   example: 1
 
+subscriptionId:
+  in: path
+  name: subscriptionId
+  required: true
+  schema:
+    type: string
+    format: uuid
+  example: "bcba82f5-48cf-44c0-b7d6-e1d32c64a88c"
+
 triggerID:
   in: path
   name: triggerID

--- a/openapi/shared/responses/_index.yml
+++ b/openapi/shared/responses/_index.yml
@@ -3,14 +3,7 @@ BadRequest:
   content:
     application/json:
       schema:
-        type: object
-        properties:
-          status:
-            description: "Generic error status text"
-            type: string
-          error:
-            type: string
-            description: "Message telling why the error occurred"
+        $ref: "../schemas/Errors.yml#/Error"
       examples:
         missingID:
           description: "no resource with the provided ID was found"
@@ -23,14 +16,7 @@ NotFound:
   content:
     application/json:
       schema:
-        type: object
-        properties:
-          status:
-            description: "Generic error status text"
-            type: string
-          error:
-            description: "Error message that describes the missing resource."
-            type: string
+        $ref: "../schemas/Errors.yml#/Error"
       examples:
         missingTrigger:
           description: "Trigger with given ID not found"
@@ -43,14 +29,7 @@ ServerError:
   content:
     application/json:
       schema:
-        type: object
-        properties:
-          status:
-            description: "Generic error status text"
-            type: string
-          error:
-            description: "Message describing the error that occurred."
-            type: string
+        $ref: "../schemas/Errors.yml#/Error"
       examples:
         renderingFailed:
           description: "Failed to render trigger chart"

--- a/openapi/shared/schemas/Errors.yml
+++ b/openapi/shared/schemas/Errors.yml
@@ -1,0 +1,12 @@
+# Error is an extensible error schema and allows individual operations
+# to customize for their use
+Error:
+  type: object
+  description: "This represents the format of a generic Moira error response."
+  properties:
+    status:
+      description: "The corresponding error status"
+      type: string
+    error:
+      type: string
+      description: "Message telling why the error occurred"

--- a/openapi/shared/schemas/Subscription.yml
+++ b/openapi/shared/schemas/Subscription.yml
@@ -1,0 +1,90 @@
+Subscription:
+  type: object
+  properties:
+    contacts:
+      type: array
+      description: "ID of contacts that are part of this subscription"
+      items:
+        type: string
+        format: uuid
+      example: ["acd2db98-1659-4a2f-b227-52d71f6e3ba1"]
+    tags:
+      type: array
+      description: "The tags for this subscription"
+      items:
+        type: string
+      example: ["server", "cpu"]
+    sched:
+      "$ref": "#/definitions/ScheduleData"
+    plotting:
+      "$ref": "#/definitions/PlottingData"
+    id:
+      type: string
+      description: "ID of this subscription"
+      example: "292516ed-4924-4154-a62c-ebe312431fce"
+    enabled:
+      type: boolean
+      description: "If false, notifications due for thsi subscription will not be sent"
+      example: true
+    any_tags:
+      type: boolean
+      example: false
+    ignore_warnings:
+      type: boolean
+      description: "If true, notifications will not be sent for warning values."
+      example: false
+    ignore_recoverings:
+      type: boolean
+      example: false
+    throttling:
+      type: boolean
+      example: false
+    user:
+      type: string
+      description: "ID of the user that created the subscription"
+      example: ""
+
+definitions:
+  PlottingData:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        example: true
+      theme:
+        type: string
+        enum: ["light", "dark"]
+        description: "Theme of the chart. Should be either 'light' or 'dark'"
+        example: "dark"
+
+  ScheduleData:
+    type: object
+    properties:
+      days:
+        items:
+          "$ref": "#/definitions/ScheduleDataDay"
+        type: array
+      tzOffset:
+        type: integer
+        description: "Timezone offset in seconds (wrt GMT)"
+        example: -60
+      startOffset:
+        type: integer
+        example: 0
+      endOffset:
+        type: integer
+        example: 1439
+
+  ScheduleDataDay:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: "Indicates if notifications should be sent on this day of the week."
+        example: true
+      name:
+        type: string
+        description: "Shortened name of the weekday"
+        enum: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+        example: "Mon"
+

--- a/openapi/shared/schemas/_index.yml
+++ b/openapi/shared/schemas/_index.yml
@@ -10,5 +10,11 @@ NotifierState:
   $ref: "./NotifierState.yml#/NotifierState"
 Pattern:
   $ref: "./Pattern.yml#/Pattern"
+Subscription:
+  $ref: "./Subscription.yml#/Subscription"
 Trigger:
   $ref: "./Trigger.yml#/Trigger"
+
+# Include generic error schema, that way operations can override them and provide custom examples
+Error:
+  $ref: "./Errors.yml#/Error"

--- a/openapi/subscription/methods.yml
+++ b/openapi/subscription/methods.yml
@@ -1,0 +1,59 @@
+subscriptions:
+  get:
+    summary: "get all subscriptions"
+    operationId: GetSubscriptions
+    tags:
+      - subscription
+    responses:
+      $ref: ./responses.yml#/getSubscription
+  put:
+    summary: "create a new subscription"
+    operationId: CreateSubscription
+    tags:
+      - subscription
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../shared/schemas/Subscription.yml#/Subscription"
+    responses:
+      $ref: ./responses.yml#/createSubscription
+subscription:
+  put:
+    summary: "update a subscription"
+    operationId: UpdateSubscription
+    tags:
+      - subscription
+    parameters:
+      - $ref: "../shared/parameters/_index.yml#/subscriptionId"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../shared/schemas/Subscription.yml#/Subscription"
+    responses:
+      $ref: ./responses.yml#/updateSubscription
+
+  delete:
+    summary: "deletes a subscription"
+    operationId: DeleteSubscription
+    tags:
+      - subscription
+    parameters:
+      - $ref: "../shared/parameters/_index.yml#/subscriptionId"
+    responses:
+      $ref: ./responses.yml#/deleteSubscription
+
+test:
+  put:
+    summary: "send test notification for a subscription"
+    operationId: TestSubscriptionNotification
+    tags:
+      - subscription
+    parameters:
+      - $ref: "../shared/parameters/_index.yml#/subscriptionId"
+    responses:
+      $ref: ./responses.yml#/testSubscriptionNotification
+

--- a/openapi/subscription/responses.yml
+++ b/openapi/subscription/responses.yml
@@ -1,0 +1,82 @@
+getSubscription:
+  200:
+    description: "subscriptions fetched successfully"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            list:
+              type: array
+              description: "list of all the available subscriptions"
+              items:
+                $ref: "../shared/schemas/Subscription.yml#/Subscription"
+
+createSubscription:
+  200:
+    description: "subscription created"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Subscription.yml#/Subscription"
+  400:
+    description: "Invalid request data"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Errors.yml#/Error"
+        examples:
+          missingField:
+            description: "a required field isn't in the request body"
+            value:
+              status: "Invalid request"
+              message: "subscription must have tags"
+      text/html:
+        schema:
+          type: string
+
+updateSubscription:
+  200:
+    description: "subscription updated"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Subscription.yml#/Subscription"
+  400:
+    description: "invalid request data"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Errors.yml#/Error"
+        examples:
+          missingField:
+            description: "a required field isn't in the request body"
+            value:
+              status: "Invalid request"
+              message: "subscription must have tags"
+          subscriptionNotFound:
+            description: "no subscription with the given ID was found"
+            value:
+              status: "Invalid request"
+              message: "subscription with ID '00' does not exist"
+      text/html:
+        schema:
+          type: string
+  404:
+    $ref: "../shared/responses/_index.yml#/NotFound"
+
+deleteSubscription:
+  200:
+    description: "subscription deleted"
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"
+  404:
+    $ref: "../shared/responses/_index.yml#/NotFound"
+
+testSubscriptionNotification:
+  200:
+    description: "test notification sent successfully"
+  400:
+    $ref: "../shared/responses/_index.yml#/BadRequest"
+  404:
+    $ref: "../shared/responses/_index.yml#/NotFound"


### PR DESCRIPTION
This adds the API docs for `/subscription` and all of its sub-paths (i.e `/subscription`, `/subscription/{subscriptionId}`, and `subscription/{subscriptionId}/test`.

It also moves the schema shared by all error responses (`status` and `message`) into a new `Error` schema, so error responses only need to define their examples and status codes now.