### PR TITLE
add description for /tag path and sub-paths

### DIFF
--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -20,6 +20,8 @@ tags:
     description: "APIs for interacting with graphite patterns in Moira. See <https://moira.readthedocs.io/en/latest/development/architecture.html#pattern/>"
   - name: "subscription"
     description: "APIs for managing a user's subscription(s). See <https://moira.readthedocs.io/en/latest/development/architecture.html#subscription/> to learn about Moira subscriptions."
+  - name: "tag"
+    description: "APIs for managing tags (a grouping of tags and subscriptions). See <https://moira.readthedocs.io/en/latest/user_guide/subscriptions.html#tags/>"
 
 servers:
   - url: http://localhost:8080/api
@@ -53,6 +55,13 @@ paths:
     $ref: ./subscription/methods.yml#/subscription
   /subscription/{subscriptionId}/test:
     $ref: ./subscription/methods.yml#/test
+  /tag:
+    $ref: ./tag/methods.yml#/tags
+  /tag/{tag}:
+    $ref: ./tag/methods.yml#/tag
+  /tag/stats:
+    $ref: ./tag/methods.yml#/stats
+
 
 
 components:

--- a/openapi/shared/parameters/_index.yml
+++ b/openapi/shared/parameters/_index.yml
@@ -72,6 +72,15 @@ subscriptionId:
     format: uuid
   example: "bcba82f5-48cf-44c0-b7d6-e1d32c64a88c"
 
+tag:
+  in: path
+  name: tag
+  required: true
+  schema:
+    type: string
+  description: "name of the tag"
+  example: "cpu"
+
 triggerID:
   in: path
   name: triggerID

--- a/openapi/shared/schemas/TagStatistics.yml
+++ b/openapi/shared/schemas/TagStatistics.yml
@@ -1,0 +1,18 @@
+TagStatistics:
+  type: object
+  properties:
+    name:
+      type: string
+      description: "name of the tag"
+      example: "cpu"
+    triggers:
+      description: "array of trigger IDs that have this tag"
+      type: array
+      items:
+        type: string
+        example: "bcba82f5-48cf-44c0-b7d6-e1d32c64a88c"
+    subscriptions:
+      type: array
+      description: "subscriptions for this tag"
+      items:
+        "$ref": "./Subscription.yml#/Subscription"

--- a/openapi/tag/methods.yml
+++ b/openapi/tag/methods.yml
@@ -1,0 +1,26 @@
+tags:
+  get:
+    summary: "get all tags"
+    operationId: GetTags
+    tags:
+      - tag
+    responses:
+      $ref: ./responses.yml#/getTags
+tag:
+  delete:
+    summary: "remove a tag"
+    operationId: DeleteTag
+    tags:
+      - tag
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/tag
+    responses:
+      $ref: ./responses.yml#/deleteTag
+stats:
+  get:
+    summary: "get all tags and subscriptions"
+    operationId: GetTagsSubscriptions
+    tags:
+      - tag
+    responses:
+      $ref: ./responses.yml#/getTagSubscriptions

--- a/openapi/tag/responses.yml
+++ b/openapi/tag/responses.yml
@@ -1,0 +1,47 @@
+getTags:
+  200:
+    description: "Tags fetched successfully"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            list:
+              type: array
+              description: "List of all the tags"
+              items:
+                type: string
+                example: "cpu"
+
+deleteTag:
+  200:
+    description: "Tag has been deleted"
+  400:
+    description: "Could not delete tag"
+    content:
+      application/json:
+        schema:
+          $ref: "../shared/schemas/Errors.yml#/Error"
+        examples:
+          tagInUse:
+            description: "no trigger with the ID was found"
+            value:
+              status: "Invalid request"
+              error: "this tag is assigned to 1 triggers. Remove tag from triggers first"
+      text/html:
+        schema:
+          type: string
+
+getTagSubscriptions:
+  200:
+    description: "Successful"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            list:
+              type: array
+              description: "list of available Moira tags, their triggers and their subscriptions"
+              items:
+                $ref: "../shared/schemas/TagStatistics.yml#/TagStatistics"


### PR DESCRIPTION
This documents the endpoints under the `/tag` path (i.e `tag`, `tag/{tag}`, and `/tag/stats`).