### PR TITLE
add documentation for /trigger and /trigger/{triggerID}

### DIFF
--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -22,6 +22,8 @@ tags:
     description: "APIs for managing a user's subscription(s). See <https://moira.readthedocs.io/en/latest/development/architecture.html#subscription/> to learn about Moira subscriptions."
   - name: "tag"
     description: "APIs for managing tags (a grouping of tags and subscriptions). See <https://moira.readthedocs.io/en/latest/user_guide/subscriptions.html#tags/>"
+  - name: "trigger"
+    description: "APIs for interacting with Moira triggers. See <https://moira.readthedocs.io/en/latest/development/architecture.html#trigger/> to learn about Triggers."
 
 servers:
   - url: http://localhost:8080/api
@@ -61,6 +63,15 @@ paths:
     $ref: ./tag/methods.yml#/tag
   /tag/stats:
     $ref: ./tag/methods.yml#/stats
+  /trigger:
+    $ref: ./trigger/methods.yml#/triggers
+  /trigger/page:
+    $ref: ./trigger/methods.yml#/page
+  /trigger/search:
+    $ref: ./trigger/methods.yml#/search
+  /trigger/{triggerID}:
+    $ref: ./trigger/methods.yml#/trigger
+
 
 
 

--- a/openapi/shared/parameters/_index.yml
+++ b/openapi/shared/parameters/_index.yml
@@ -27,6 +27,15 @@ notificationId:
   description: The ID of updated trigger
   example: 5A8AF369-86D2-44DD-B514-D47995ED6AF7
 
+onlyProblems:
+  in: query
+  name: onlyProblems
+  required: false
+  schema:
+    type: boolean
+  description: Restricts the result to errors only
+  example: false
+
 page:
   in: query
   name: page
@@ -80,6 +89,15 @@ tag:
     type: string
   description: "name of the tag"
   example: "cpu"
+
+text:
+  in: query
+  name: text
+  required: true
+  schema:
+    type: string
+  description: query to perform a search for
+  example: cpu
 
 triggerID:
   in: path

--- a/openapi/trigger/methods.yml
+++ b/openapi/trigger/methods.yml
@@ -1,0 +1,86 @@
+triggers:
+  get:
+    summary: "get all triggers"
+    operationId: GetTriggers
+    tags:
+      - trigger
+    responses:
+      $ref: ./responses.yml#/triggers/getTriggers
+
+  put:
+    summary: "create new trigger"
+    operationId: CreateTrigger
+    tags:
+      - trigger
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ./requests.yml#/createTrigger
+    responses:
+      $ref: ./responses.yml#/triggers/createTrigger
+
+trigger:
+  put:
+    summary: "Update existing trigger"
+    operationId: UpdateTrigger
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../shared/schemas/Trigger.yml#/Trigger"
+    responses:
+      $ref: responses.yml#/trigger/updateTrigger
+
+  get:
+    summary: "Get an existing trigger"
+    operationId: GetTrigger
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    responses:
+      $ref: ./responses.yml#/trigger/getTrigger
+
+  delete:
+    summary: "remove a trigger"
+    operationId: DeleteTrigger
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    responses:
+      $ref: ./responses.yml#/trigger/deleteTrigger
+
+page:
+  get:
+    summary: "Search triggers. Deprecated, use the `search` endpoint instead"
+    deprecated: true
+    operationId: SearchTriggersPage
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/onlyProblems
+      - $ref: ../shared/parameters/_index.yml#/page
+      - $ref: ../shared/parameters/_index.yml#/text
+    responses:
+      $ref: ./responses.yml#/pageTriggers
+
+search:
+  get:
+    summary: "Search triggers. Replaces the deprecated `page` path"
+    operationId: SearchTriggers
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/onlyProblems
+      - $ref: ../shared/parameters/_index.yml#/page
+      - $ref: ../shared/parameters/_index.yml#/text
+    responses:
+      $ref: ./responses.yml#/searchTriggers

--- a/openapi/trigger/requests.yml
+++ b/openapi/trigger/requests.yml
@@ -1,0 +1,2 @@
+createTrigger:
+  $ref: "../shared/schemas/Trigger.yml#/Trigger"

--- a/openapi/trigger/responses.yml
+++ b/openapi/trigger/responses.yml
@@ -1,0 +1,119 @@
+triggers:
+  getTriggers:
+    200:
+      description: "fetched all triggers"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              list:
+                type: array
+                description: "list of available triggers"
+                items:
+                  $ref: "../shared/schemas/Trigger.yml#/Trigger"
+
+  createTrigger:
+    200:
+      description: "Trigger created"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                example: trigger_id
+              message:
+                type: string
+                example: trigger created
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+trigger:
+  deleteTrigger:
+    200:
+      description: "Trigger has been deleted"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+  updateTrigger:
+    200:
+      description: "Trigger updated"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                example: trigger_id
+              message:
+                type: string
+                example: trigger created
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+  getTrigger:
+    200:
+      description: "Trigger data"
+      content:
+        application/json:
+          schema:
+            $ref: "../shared/schemas/Trigger.yml#/Trigger"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+    404:
+      $ref: "../shared/responses/_index.yml#/NotFound"
+
+pageTriggers:
+  200:
+    description: "fetched matching triggers"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            page:
+              type: number
+              description: "current item page"
+              example: 0
+            size:
+              type: number
+              description: "number of triggers shown per page"
+              example: 10
+            total:
+              type: number
+              description: "total number of matching results"
+              example: 5
+            list:
+              type: array
+              description: "list of matching triggers"
+              items:
+                $ref: "../shared/schemas/Trigger.yml#/Trigger"
+
+searchTriggers:
+  200:
+    description: "fetched matching triggers"
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            page:
+              type: number
+              description: "current item page"
+              example: 0
+            size:
+              type: number
+              description: "number of triggers shown per page"
+              example: 10
+            total:
+              type: number
+              description: "total number of matching results"
+              example: 5
+            list:
+              type: array
+              description: "list of matching triggers"
+              items:
+                $ref: "../shared/schemas/Trigger.yml#/Trigger"


### PR DESCRIPTION
This adds the OpenAPI documentation for the `/trigger` path and the `/trigger/{triggerID}` sub-path. It documents `/trigger/search` and `/trigger/page` (which has been deprecated in the Moira API code).

Because of the number of sub-paths under `/trigger`, endpoints for individual triggers (such as metrics and render) are omitted from this PR and will be added separately.