### PR TITLE
add test rule to Makefile and integrate with CI

### DIFF
--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: moira-alert/moira
+          repository: moira-alert/docker-compose
       - name: Set up docker services
         run: docker-compose up -d
 

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: moira-alert/moira
-      - run: ls -R
       - name: Set up docker services
         run: docker-compose up -d
 
@@ -71,7 +70,7 @@ jobs:
   publishspec:
     name: Upload generated OpenAPI description
     runs-on: ubuntu-latest
-    needs: mergespec
+    needs: testspec
     defaults:
       run:
         working-directory: openapi

--- a/.github/workflows/swaggerhub-publish.yml
+++ b/.github/workflows/swaggerhub-publish.yml
@@ -30,6 +30,43 @@ jobs:
         with:
           name: specfile
           path: openapi/build/openapi.yml
+
+  testspec:
+    name: Test generated spec against the Moira API
+    runs-on: ubuntu-latest
+    needs: mergespec
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: moira-alert/moira
+      - run: ls -R
+      - name: Set up docker services
+        run: docker-compose up -d
+
+      # Checkout again to switch back to `doc` repository
+      - uses: actions/checkout@v2
+
+      - name: Download spec file artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: specfile
+          path: openapi/build
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install schemathesis and run tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install schemathesis
+          cd openapi
+          make test-spec
     
   publishspec:
     name: Upload generated OpenAPI description

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 source/_build_html
 source/_build
 .vscode
+openapi/.hypothesis

--- a/openapi/Makefile
+++ b/openapi/Makefile
@@ -1,5 +1,7 @@
 BUILD_DIR = build
 SPEC_FILE = $(BUILD_DIR)/openapi.yml
+TESTS_LOG_FILE  = $(BUILD_DIR)/cassette.yml
+API_URL = "http://localhost:8080/api"
 
 spec:
 	swagger-cli bundle main.yml -o $(SPEC_FILE) -t yaml
@@ -7,3 +9,11 @@ spec:
 validate-spec:
 	openapi-generator validate -i $(SPEC_FILE)
 
+test-spec:
+	schemathesis run \
+	--base-url=$(API_URL) $(SPEC_FILE) \
+	--checks all \
+ 	--store-network-log $(TESTS_LOG_FILE) \
+ 	--show-errors-tracebacks \
+ 	--hypothesis-verbosity verbose \
+ 	--hypothesis-max-examples 1 \


### PR DESCRIPTION

This adds support for testing the documentation against the API.
The data sent in the requests are based on the examples we define in our OpenAPI document, for example, given the OpenAPI spec below:
```yml
ContactRequest:
  type: object
  description: "Format of the request body for POST/PUT requests to `/contacts` and related sub-paths."
  properties:
    type:
      type: string
      example: "mail"
    value:
      type: string
      example: "devops@example.com"
```
Schemathesis will generate this request payload:
```json
{
  "type": "mail", 
  "value": "devops@example.com"
}
```

Schemathesis checks the response code, content type, and the schema of the JSON response.
The test fails if none of it matches what is in the OpenAPI spec.

The request and response body is logged in build/cassette.yml,
and the output is set to `verbose` mode so all the data can be seen on stdout.