### PR TITLE
Document single trigger operations

### DIFF
--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -75,8 +75,8 @@ paths:
     $ref: ./trigger/methods.yml#/metrics
   /trigger/{triggerID}/metrics/nodata:
     $ref: ./trigger/methods.yml#/metricsNoData
-  /trigger/{triggerID}/render:
-    $ref: ./trigger/methods.yml#/render
+  #/trigger/{triggerID}/render:
+  #  $ref: ./trigger/methods.yml#/render
   /trigger/{triggerID}/setMaintenance:
     $ref: ./trigger/methods.yml#/setMaintenance
   /trigger/{triggerID}/state:

--- a/openapi/main.yml
+++ b/openapi/main.yml
@@ -71,9 +71,18 @@ paths:
     $ref: ./trigger/methods.yml#/search
   /trigger/{triggerID}:
     $ref: ./trigger/methods.yml#/trigger
-
-
-
+  /trigger/{triggerID}/metrics:
+    $ref: ./trigger/methods.yml#/metrics
+  /trigger/{triggerID}/metrics/nodata:
+    $ref: ./trigger/methods.yml#/metricsNoData
+  /trigger/{triggerID}/render:
+    $ref: ./trigger/methods.yml#/render
+  /trigger/{triggerID}/setMaintenance:
+    $ref: ./trigger/methods.yml#/setMaintenance
+  /trigger/{triggerID}/state:
+    $ref: ./trigger/methods.yml#/state
+  /trigger/{triggerID}/throttling:
+    $ref: ./trigger/methods.yml#/throttling
 
 components:
   schemas:

--- a/openapi/shared/parameters/_index.yml
+++ b/openapi/shared/parameters/_index.yml
@@ -17,6 +17,25 @@ end:
     default: -1
   example: 15
 
+from:
+  in: query
+  name: from
+  required: false
+  schema:
+    type: string
+  description: The start period of metrics to get
+  example: -1hour
+
+metricName:
+  in: query
+  name: name
+  required: true
+  schema:
+    type: string
+  description: Name of the target metric
+  example: "DevOps.my_server.hdd.freespace_mbytes"
+
+
 notificationId:
   in: query
   name: notificationId
@@ -89,6 +108,24 @@ tag:
     type: string
   description: "name of the tag"
   example: "cpu"
+
+targetID:
+  in: query
+  name: targetID
+  required: false
+  schema:
+    type: string
+  description: The ID of updated target to print plot for
+  example: t1
+
+to:
+  in: query
+  name: to
+  required: false
+  schema:
+    type: string
+  description: The end period of metrics to get
+  example: now
 
 text:
   in: query

--- a/openapi/shared/schemas/MetricValue.yml
+++ b/openapi/shared/schemas/MetricValue.yml
@@ -1,0 +1,9 @@
+MetricValue:
+  type: object
+  properties:
+    step:
+      type: integer
+    ts:
+      type: integer
+    value:
+      type: number

--- a/openapi/shared/schemas/TriggerCheck.yml
+++ b/openapi/shared/schemas/TriggerCheck.yml
@@ -1,0 +1,71 @@
+TriggerCheck:
+  properties:
+    metrics:
+      "$ref": "#/MetricState"
+    score:
+      type: integer
+      example: 100
+    state:
+      type: string
+      example: "OK"
+    maintenance:
+      type: integer
+    maintenance_info:
+      "$ref": "#/MaintenanceInfo"
+    timestamp:
+      type: integer
+      example: 1590741916
+    event_timestamp:
+      type: integer
+      example: 1590741878
+    last_successful_check_timestamp:
+      type: integer
+      example: 1590741916
+    suppressed:
+      type: boolean
+    suppressed_state:
+      type: string
+    msg:
+      type: string
+    trigger_id:
+      type: string
+  additionalProperties: false
+  type: object
+
+MaintenanceInfo:
+  type: object
+  properties:
+    setup_user:
+      type: string
+    setup_time:
+      type: integer
+    remove_user:
+      type: string
+    remove_time:
+      type: integer
+
+MetricState:
+  properties:
+    event_timestamp:
+      type: integer
+      example: 1590741878
+    state:
+      type: string
+      example: "OK"
+    suppressed:
+      type: boolean
+      example: false
+    suppressed_state:
+      type: string
+    timestamp:
+      type: integer
+      example: 1590741878
+    value:
+      type: number
+      example: 70
+    maintenance:
+      type: integer
+    maintenance_info:
+      "$ref": "#/MaintenanceInfo"
+  additionalProperties: false
+  type: object

--- a/openapi/shared/schemas/_index.yml
+++ b/openapi/shared/schemas/_index.yml
@@ -4,6 +4,10 @@ ContactRequest:
   $ref: "./Contact.yml#/ContactRequest"
 Event:
   $ref: "./Event.yml#/Event"
+MaintenanceInfo:
+  $ref: "./TriggerCheck.yml#/MaintenanceInfo"
+MetricState:
+  $ref: "./TriggerCheck.yml#/MetricState"
 NotificationsList:
   $ref: "./NotificationsList.yml#/NotificationsList"
 NotifierState:
@@ -14,7 +18,8 @@ Subscription:
   $ref: "./Subscription.yml#/Subscription"
 Trigger:
   $ref: "./Trigger.yml#/Trigger"
-
+TriggerCheck:
+  $ref: "./TriggerCheck.yml#/TriggerCheck"
 # Include generic error schema, that way operations can override them and provide custom examples
 Error:
   $ref: "./Errors.yml#/Error"

--- a/openapi/trigger/methods.yml
+++ b/openapi/trigger/methods.yml
@@ -84,3 +84,102 @@ search:
       - $ref: ../shared/parameters/_index.yml#/text
     responses:
       $ref: ./responses.yml#/searchTriggers
+
+render:
+  get:
+    summary: "Get rendered plot for trigger"
+    operationId: GetTriggerPlot
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+      - $ref: ../shared/parameters/_index.yml#/targetID
+      - $ref: ../shared/parameters/_index.yml#/from
+      - $ref: ../shared/parameters/_index.yml#/to
+    responses:
+      $ref: ./responses.yml#/render/getTriggerChart
+
+setMaintenance:
+  put:
+    summary: "sets metrics and the trigger itself to maintenance mode"
+    operationId: SetTriggerMaintenance
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            anyOf:
+              - $ref: ./requests.yml#/setMaintenance/trigger
+              - $ref: ./requests.yml#/setMaintenance/metrics
+    responses:
+      $ref: ./responses.yml#/setMaintenance/scheduleMaintenance
+
+metrics:
+  get:
+    summary: "Get metrics associated with certain trigger"
+    operationId: GetTriggerMetrics
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+      - $ref: ../shared/parameters/_index.yml#/from
+      - $ref: ../shared/parameters/_index.yml#/to
+    responses:
+      $ref: ./responses.yml#/metrics/getMetrics
+  delete:
+    summary: "deletes metric from last check and all trigger pattern metrics"
+    operationId: DeleteTriggerMetric
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+      - $ref: ../shared/parameters/_index.yml#/metricName
+    responses:
+      $ref: ./responses.yml#/metrics/deleteMetrics
+
+metricsNoData:
+  delete:
+    summary: "deletes all metrics from last data which are in NODATA state. It also deletes all trigger patterns of those metrics"
+    operationId: DeleteTriggerNoDataMetrics
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    responses:
+      $ref: ./responses.yml#/metricsNoData/delete
+
+state:
+  get:
+    summary: "Get the trigger state as at last check"
+    operationId: GetTriggerState
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    responses:
+      $ref: ./responses.yml#/state/getTriggerState
+
+throttling:
+  get:
+    summary: "Get a trigger with its throttling i.e its next allowed message time"
+    operationId: GetTriggerThrottling
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    responses:
+      $ref: ./responses.yml#/throttling/getThrottleInfo
+  delete:
+    summary: "Deletes throttling for a trigger"
+    operationId: DeleteTriggerThrottling
+    tags:
+      - trigger
+    parameters:
+      - $ref: ../shared/parameters/_index.yml#/triggerID
+    responses:
+      $ref: ./responses.yml#/throttling/deleteThrottleInfo
+

--- a/openapi/trigger/requests.yml
+++ b/openapi/trigger/requests.yml
@@ -1,2 +1,18 @@
 createTrigger:
   $ref: "../shared/schemas/Trigger.yml#/Trigger"
+
+setMaintenance:
+  trigger:
+    type: object
+    properties:
+      trigger:
+        type: integer
+        description: "Unix timestamp for when the maintenance should be over"
+        example: 1594225165
+  metrics:
+    type: object
+    properties:
+      metrics:
+        type: object
+        description: "JSON object (i.e key value pair) of the metric and the unix time to end the scheduled maintenance"
+        example: '{"devops.*": 1594225165}'

--- a/openapi/trigger/responses.yml
+++ b/openapi/trigger/responses.yml
@@ -117,3 +117,92 @@ searchTriggers:
               description: "list of matching triggers"
               items:
                 $ref: "../shared/schemas/Trigger.yml#/Trigger"
+metrics:
+  deleteMetrics:
+    200:
+      description: "Trigger metric has been deleted"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+  getMetrics:
+    200:
+      description: "Metrics for trigger"
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                $ref: "../shared/schemas/MetricValue.yml#/MetricValue"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+    500:
+      $ref: "../shared/responses/_index.yml#/ServerError"
+
+metricsNoData:
+  delete:
+    200:
+      description: "NODATA metrics have been deleted"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+render:
+  getTriggerChart:
+    200:
+      description: "Plot for trigger"
+      content:
+        image/png:
+          schema:
+            type: string
+            format: binary
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+    404:
+      $ref: "../shared/responses/_index.yml#/NotFound"
+    500:
+      $ref: "../shared/responses/_index.yml#/ServerError"
+
+state:
+  getTriggerState:
+    200:
+      description: "trigger state fetched successfully"
+      content:
+        application/json:
+          schema:
+            $ref: "../shared/schemas/TriggerCheck.yml#/TriggerCheck"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+setMaintenance:
+  scheduleMaintenance:
+    200:
+      description: "trigger or metric have been scheduled for maintenance"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+
+throttling:
+  getThrottleInfo:
+    200:
+      description: "trigger throttle info retrieved"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              throttling:
+                type: integer
+                description: "unix timestamp to show next allowed time, defaults to 0"
+                example: 0
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"
+    404:
+      $ref: "../shared/responses/_index.yml#/NotFound"
+
+  deleteThrottleInfo:
+    200:
+      description: "trigger throttling has been deleted"
+    404:
+      $ref: "../shared/responses/_index.yml#/NotFound"
+    400:
+      $ref: "../shared/responses/_index.yml#/BadRequest"


### PR DESCRIPTION
In last trigger PR, we excluded API operations that deals with single triggers
from the documentation to reduce commit size. Some of such excluded operations include: `/trigger/{triggerID}/metrics`, `/trigger/{triggerID}/throttling`, `/trigger/{triggerID}/state`, etc.

This adds their documentation to the OpenAPI document. Also, the trigger render path `/trigger/{triggerID}/render` has been commented out as it causes test failure (due to returning 500 error when a trigger is not found).