### PR TITLE
ci: add client libraries generation rules

### DIFF
--- a/.github/workflows/build-client-libraries.yml
+++ b/.github/workflows/build-client-libraries.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           git config user.email "${{ secrets.GIT_EMAIL }}"
           git config user.name "${{ secrets.GIT_USERNAME }}"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ secrets.CLIENT_LIBRARY_REPOSITORY }}
           git add clients
           git commit -m "automated build for client libraries"
           git push

--- a/.github/workflows/build-client-libraries.yml
+++ b/.github/workflows/build-client-libraries.yml
@@ -1,0 +1,65 @@
+name: Build client libraries from OpenAPI spec
+defaults:
+  run:
+    working-directory: openapi
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  bundlespec:
+    name: Bundle multiple spec files and validate it
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: npm install -g swagger-cli @openapitools/openapi-generator-cli
+      - run: make spec
+      - run: make validate-spec
+
+      - name: Save build artifcat
+        uses: actions/upload-artifact@v1
+        with:
+          name: specfile
+          path: openapi/build/openapi.yml
+
+  build-ts-library:
+    name: Build client libraries and push to their repos
+    runs-on: ubuntu-latest
+    needs: bundlespec
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: mkdir build/
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: npm install -g @openapitools/openapi-generator-cli
+      - name: Download OpenAPI spec file
+        uses: actions/download-artifact@v1
+        with:
+          name: specfile
+          path: openapi/build
+
+      - name: Build client libraries
+        run: |
+          make generate-py
+          make generate-go
+          make generate-ts
+          make generate-cs
+
+      - name: Commit generated client libraries
+        run: |
+          git config user.email "${{ secrets.GIT_EMAIL }}"
+          git config user.name "${{ secrets.GIT_USERNAME }}"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git add clients
+          git commit -m "automated build for client libraries"
+          git push

--- a/.github/workflows/build-client-libraries.yml
+++ b/.github/workflows/build-client-libraries.yml
@@ -29,7 +29,7 @@ jobs:
           name: specfile
           path: openapi/build/openapi.yml
 
-  build-ts-library:
+  build-clients:
     name: Build client libraries and push to their repos
     runs-on: ubuntu-latest
     needs: bundlespec

--- a/openapi/Makefile
+++ b/openapi/Makefile
@@ -1,4 +1,5 @@
 BUILD_DIR = build
+CLIENTS_DIR = clients
 SPEC_FILE = $(BUILD_DIR)/openapi.yml
 TESTS_LOG_FILE  = $(BUILD_DIR)/cassette.yml
 API_URL = "http://localhost:8080/api"
@@ -17,3 +18,13 @@ test-spec:
  	--show-errors-tracebacks \
  	--hypothesis-verbosity verbose \
  	--hypothesis-max-examples 1 \
+
+generate-py:
+	openapi-generator generate -g python -i $(SPEC_FILE) -o $(CLIENTS_DIR)/python
+generate-go:
+	openapi-generator generate -g go -i $(SPEC_FILE) -o $(CLIENTS_DIR)/go
+generate-ts:
+	openapi-generator generate -g typescript-node -i $(SPEC_FILE) -o $(CLIENTS_DIR)/ts-node
+generate-cs:
+	openapi-generator generate -g csharp -i $(SPEC_FILE) -o $(CLIENTS_DIR)/csharp
+


### PR DESCRIPTION
This adds the commands to generate client libraries from the openapi spec to the Makefile. Supported languages are (python, c#, go and typescript).

It also creates a `clients` folder in the repository which it commits the libraries to (on push to master).
For the Actions pipelines to work,  `GIT_EMAIL` and `GIT_USERNAME` should be configured as GitHub secret tokens as they are needed for the `git commit` command.