### PR TITLE
add docs build on pr

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,18 @@
+name: "Sphinx Docs Check"
+on: 
+- pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "./"
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: build/html/
+        commit_message: "branch: ${{ github.head_ref }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-Sphinx==1.8.5
+Sphinx==3.5.4
 sphinx-rtd-theme
 sphinxcontrib-httpdomain
 sphinxcontrib-images


### PR DESCRIPTION
Used GH action [sphinx-build](https://github.com/marketplace/actions/sphinx-build) to check docs in CI workflow.

Features:
 * show warnings in diff lines
 * PR docs deploy on GH Pages  http://moira-alert.github.io/doc/