### PR TITLE
Updated redis section in example configs

### DIFF
--- a/api.example.yml
+++ b/api.example.yml
@@ -1,22 +1,30 @@
-# Use fields MasterName and SentinelAddrs to enable Redis Sentinel support,
-# use Host and Port fields otherwise.
+# Redis configuration depends on fields specified in redis config section:
+# 1. Use field `master_name` to enable Redis Sentinel support
+# 2. Specify two or more `addrs` to enable cluster support
+# 3. Otherwise, standalone configuration is enabled
 redis:
-  # Sentinel cluster name
+  # Sentinel master name
   master_name: ""
-  # Sentinel address list, format: {host1_name:port};{ip:port}
-  sentinel_addrs: ""
-  # Node ip-address or host name
-  host: "moira-redis"
-  # Node port
-  port: "6379"
-  # Database id
-  dbid: 0
-  # Redis client connection pool size
-  connection_limit: 512
-  # Allow reading data from slave replicas
-  allow_slave_reads: true
-  # Delete metrics older than this value from Redis
+  # address list, format: {host1_name:port},{ip:port}
+  addrs: "localhost:6379"
+  # Redis username
+  username: "username"
+  # Redis password
+  password: "password"
+  # Moira will delete metrics older than this value from Redis. Large values will lead to various problems everywhere.
+  # See https://github.com/moira-alert/moira/pull/519
   metrics_ttl: 3h
+  # Dial timeout for establishing new connections
+  # Default is 500 milliseconds
+  dial_timeout: 1s
+  # Timeout for socket reads. If reached, commands will fail
+  # with a timeout instead of blocking. Default is 3 seconds.
+  # Skip this setting or set 0 for default.
+  read_timeout: 5s
+  # Timeout for socket writes. If reached, commands will fail
+  # with a timeout instead of blocking. Default is ReadTimeout.
+  # Skip this setting or set 0 for default.
+  write_timeout: 5s
 telemetry:
   # Common port for all telemetry data: Prometheus scraping, pprof, etc.
   listen: ":8091"

--- a/checker.example.yml
+++ b/checker.example.yml
@@ -1,22 +1,30 @@
-# Use fields MasterName and SentinelAddrs to enable Redis Sentinel support,
-# use Host and Port fields otherwise.
+# Redis configuration depends on fields specified in redis config section:
+# 1. Use field `master_name` to enable Redis Sentinel support
+# 2. Specify two or more `addrs` to enable cluster support
+# 3. Otherwise, standalone configuration is enabled
 redis:
-  # Sentinel cluster name
+  # Sentinel master name
   master_name: ""
-  # Sentinel address list, format: {host1_name:port};{ip:port}
-  sentinel_addrs: ""
-  # Node ip-address or host name
-  host: "moira-redis"
-  # Node port
-  port: "6379"
-  # Database id
-  dbid: 0
-  # Redis client connection pool size
-  connection_limit: 512
-  # Allow reading data from slave replicas
-  allow_slave_reads: true
-  # Delete metrics older than this value from Redis
+  # address list, format: {host1_name:port},{ip:port}
+  addrs: "localhost:6379"
+  # Redis username
+  username: "username"
+  # Redis password
+  password: "password"
+  # Moira will delete metrics older than this value from Redis. Large values will lead to various problems everywhere.
+  # See https://github.com/moira-alert/moira/pull/519
   metrics_ttl: 3h
+  # Dial timeout for establishing new connections
+  # Default is 500 milliseconds
+  dial_timeout: 1s
+  # Timeout for socket reads. If reached, commands will fail
+  # with a timeout instead of blocking. Default is 3 seconds.
+  # Skip this setting or set 0 for default.
+  read_timeout: 5s
+  # Timeout for socket writes. If reached, commands will fail
+  # with a timeout instead of blocking. Default is ReadTimeout.
+  # Skip this setting or set 0 for default.
+  write_timeout: 5s
 telemetry:
   # Common port for all telemetry data: Prometheus scraping, pprof, etc.
   listen: ":8091"

--- a/filter.example.yml
+++ b/filter.example.yml
@@ -1,22 +1,30 @@
-# Use fields MasterName and SentinelAddrs to enable Redis Sentinel support,
-# use Host and Port fields otherwise.
+# Redis configuration depends on fields specified in redis config section:
+# 1. Use field `master_name` to enable Redis Sentinel support
+# 2. Specify two or more `addrs` to enable cluster support
+# 3. Otherwise, standalone configuration is enabled
 redis:
-  # Sentinel cluster name
+  # Sentinel master name
   master_name: ""
-  # Sentinel address list, format: {host1_name:port};{ip:port}
-  sentinel_addrs: ""
-  # Node ip-address or host name
-  host: "moira-redis"
-  # Node port
-  port: "6379"
-  # Database id
-  dbid: 0
-  # Redis client connection pool size
-  connection_limit: 512
-  # Allow reading data from slave replicas
-  allow_slave_reads: true
-  # Delete metrics older than this value from Redis
+  # address list, format: {host1_name:port},{ip:port}
+  addrs: "localhost:6379"
+  # Redis username
+  username: "username"
+  # Redis password
+  password: "password"
+  # Moira will delete metrics older than this value from Redis. Large values will lead to various problems everywhere.
+  # See https://github.com/moira-alert/moira/pull/519
   metrics_ttl: 3h
+  # Dial timeout for establishing new connections
+  # Default is 500 milliseconds
+  dial_timeout: 1s
+  # Timeout for socket reads. If reached, commands will fail
+  # with a timeout instead of blocking. Default is 3 seconds.
+  # Skip this setting or set 0 for default.
+  read_timeout: 5s
+  # Timeout for socket writes. If reached, commands will fail
+  # with a timeout instead of blocking. Default is ReadTimeout.
+  # Skip this setting or set 0 for default.
+  write_timeout: 5s
 telemetry:
   # Common port for all telemetry data: Prometheus scraping, pprof, etc.
   listen: ":8091"

--- a/notifier.example.yml
+++ b/notifier.example.yml
@@ -1,22 +1,30 @@
-# Use fields MasterName and SentinelAddrs to enable Redis Sentinel support,
-# use Host and Port fields otherwise.
+# Redis configuration depends on fields specified in redis config section:
+# 1. Use field `master_name` to enable Redis Sentinel support
+# 2. Specify two or more `addrs` to enable cluster support
+# 3. Otherwise, standalone configuration is enabled
 redis:
-  # Sentinel cluster name
+  # Sentinel master name
   master_name: ""
-  # Sentinel address list, format: {host1_name:port};{ip:port}
-  sentinel_addrs: ""
-  # Node ip-address or host name
-  host: "moira-redis"
-  # Node port
-  port: "6379"
-  # Database id
-  dbid: 0
-  # Redis client connection pool size
-  connection_limit: 512
-  # Allow reading data from slave replicas
-  allow_slave_reads: true
-  # Delete metrics older than this value from Redis
+  # address list, format: {host1_name:port},{ip:port}
+  addrs: "localhost:6379"
+  # Redis username
+  username: "username"
+  # Redis password
+  password: "password"
+  # Moira will delete metrics older than this value from Redis. Large values will lead to various problems everywhere.
+  # See https://github.com/moira-alert/moira/pull/519
   metrics_ttl: 3h
+  # Dial timeout for establishing new connections
+  # Default is 500 milliseconds
+  dial_timeout: 1s
+  # Timeout for socket reads. If reached, commands will fail
+  # with a timeout instead of blocking. Default is 3 seconds.
+  # Skip this setting or set 0 for default.
+  read_timeout: 5s
+  # Timeout for socket writes. If reached, commands will fail
+  # with a timeout instead of blocking. Default is ReadTimeout.
+  # Skip this setting or set 0 for default.
+  write_timeout: 5s
 telemetry:
   # Common port for all telemetry data: Prometheus scraping, pprof, etc.
   listen: ":8091"


### PR DESCRIPTION
This PR updates redis section in config examples for checker, filter, api and notifier to accomadate changes with moving to go-redis.