### PR TITLE
fix: event type in webhook

### DIFF
--- a/source/installation/webhooks_scripts.rst
+++ b/source/installation/webhooks_scripts.rst
@@ -113,8 +113,8 @@ metric        String  Metric name
 value         Float64 Metric value
 timestamp     Int64   Event timestamp
 trigger_event Bool    Event type
-state         String  Current metric state
-old_state     String  Previous metric state
+state         State   Current metric state
+old_state     State   Previous metric state
 ============= ======= =====================
 
 


### PR DESCRIPTION
Change type of `eventData.{State, OldState}` from `String` to `moira.State`